### PR TITLE
[FIX]: Query string seed

### DIFF
--- a/main.js
+++ b/main.js
@@ -72,7 +72,7 @@ class CubeManager {
     }
 
     resolveSeedOnInit() {
-        let seed = new URL(location.href).searchParams.get('s') ?? void 0;
+        let seed = +new URL(location.href).searchParams.get('s') || void 0;
         if (seed) {
             history.replaceState({}, '', location.pathname);
             if (!isValidSeed(seed)) seed = void 0;


### PR DESCRIPTION
Repro: ?s=1234567
Expected result: The same game as when entering seed via UI
Actual result: A different game

Seed passed as a query string:
![Screenshot 2023-05-22 at 16-04-30 Cubes](https://github.com/Kiryhas/memechain/assets/49142579/ba5a929b-bcda-488a-9bb7-abcd78da6af0)
Seed entered via UI:
![Screenshot 2023-05-22 at 16-04-37 Cubes](https://github.com/Kiryhas/memechain/assets/49142579/1938ebcb-e7fa-4045-91c4-aa3f58a0aa74)

